### PR TITLE
Move addon liveness-probe creation to system namespace

### DIFF
--- a/internal/health/controller.go
+++ b/internal/health/controller.go
@@ -15,6 +15,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const (
+	probeName      = "liveness-probe"
+	probeNamespace = "kyma-system"
+)
+
 // ControllerHealth holds logic for controller's probes
 type ControllerHealth struct {
 	port    string
@@ -66,9 +71,6 @@ func (c *ControllerHealth) runFullControllersCycle(client client.Client, lg *log
 }
 
 func (c *ControllerHealth) runAddonsConfigurationControllerCycle(req *http.Request, client client.Client, lg *logrus.Entry) error {
-	probeName := "liveness-probe"
-	probeNamespace := "default"
-
 	addonsConfiguration := &v1alpha1.AddonsConfiguration{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      probeName,
@@ -135,8 +137,6 @@ func (c *ControllerHealth) runAddonsConfigurationControllerCycle(req *http.Reque
 }
 
 func (c *ControllerHealth) runClusterAddonsConfigurationControllerCycle(req *http.Request, client client.Client, lg *logrus.Entry) error {
-	probeName := "liveness-probe"
-
 	clusterAddonsConfiguration := &v1alpha1.ClusterAddonsConfiguration{
 		ObjectMeta: v1.ObjectMeta{
 			Name: probeName,


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/master/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/master/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**
Helm-Broker liveness probe creates sample AddonsConfiguration and ClusterAddonsConfiguration resources, which results in addons showing up on Kyma Console with status failed, which is misleading to users. 

Changes proposed in this pull request:

- Moved creation of "liveness-probe" AddonsConfiguration from **default** to **system** namespace

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
[#6359](https://github.com/kyma-project/kyma/issues/6359)
