### PR TITLE
Remove outdated library in Helm Broker

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -801,14 +801,6 @@
   version = "v1.2.1"
 
 [[projects]]
-  branch = "master"
-  digest = "1:47c63c4edd0d5c6a8063e51dedf865dc53200efd12f2a82bc86c3c25e636e626"
-  name = "github.com/komkom/go-jsonhash"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "a6a43ccde81e32de31ce3c12f12f510568a96c94"
-
-[[projects]]
   digest = "1:0a69a1c0db3591fcefb47f115b224592c8dfa4368b7ba9fae509d5e16cdc95c8"
   name = "github.com/konsorten/go-windows-terminal-sequences"
   packages = ["."]
@@ -2005,7 +1997,6 @@
     "github.com/hashicorp/go-getter/helper/url",
     "github.com/hashicorp/go-multierror",
     "github.com/imdario/mergo",
-    "github.com/komkom/go-jsonhash",
     "github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1",
     "github.com/kyma-project/kyma/components/application-gateway/pkg/httpconsts",
     "github.com/kyma-project/kyma/components/cms-controller-manager/pkg/apis/cms/v1alpha1",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -77,10 +77,6 @@ required= [
   branch = "master"
 
 [[constraint]]
-  name = "github.com/komkom/go-jsonhash"
-  branch = "master"
-
-[[constraint]]
   name = "k8s.io/helm"
   # If you change that version be aware that you need to align it in the kyma/docs/helm-broker/03-05-addons-validation.md
   version = "2.8.2"

--- a/internal/bind/renderer_test.go
+++ b/internal/bind/renderer_test.go
@@ -172,7 +172,7 @@ func fixInstance() internal.Instance {
 				Raw: "raw-config",
 			},
 		},
-		ProvisioningParameters: &internal.ProvisioningParameters{
+		ProvisioningParameters: &internal.RequestParameters{
 			Data: map[string]interface{}{
 				"sample-parameter": "sample-value",
 			},

--- a/internal/bind/renderer_test.go
+++ b/internal/bind/renderer_test.go
@@ -162,7 +162,6 @@ func fixInstance() internal.Instance {
 		ServicePlanID: "test-service-plan-id",
 		ReleaseName:   "test-release",
 		Namespace:     "test-ns",
-		ParamsHash:    "test-hash",
 		ReleaseInfo: internal.ReleaseInfo{
 			Time: &google_protobuf.Timestamp{
 				Seconds: 123123123,
@@ -171,6 +170,11 @@ func fixInstance() internal.Instance {
 			Revision: 123,
 			Config: &chart.Config{
 				Raw: "raw-config",
+			},
+		},
+		ProvisioningParameters: &internal.ProvisioningParameters{
+			Data: map[string]interface{}{
+				"sample-parameter": "sample-value",
 			},
 		},
 	}

--- a/internal/broker/bind.go
+++ b/internal/broker/bind.go
@@ -256,7 +256,6 @@ func (svc *bindService) prepareBindOperation(iID internal.InstanceID, bID intern
 		OperationID: opID,
 		Type:        internal.OperationTypeCreate,
 		State:       internal.OperationStateInProgress,
-		ParamsHash:  paramHash,
 	}
 
 	return op, nil

--- a/internal/broker/bind.go
+++ b/internal/broker/bind.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"sync"
 
-	jsonhash "github.com/komkom/go-jsonhash"
 	"github.com/pkg/errors"
 	osb "github.com/pmorie/go-open-service-broker-client/v2"
 	"github.com/sirupsen/logrus"
@@ -53,8 +52,6 @@ func (svc *bindService) Bind(ctx context.Context, osbCtx OsbContext, req *osb.Bi
 		return nil, &osb.HTTPStatusCodeError{StatusCode: http.StatusBadRequest, ErrorMessage: strPtr(fmt.Sprintf("while validating bind request: %v", err))}
 	}
 
-	paramHash := jsonhash.HashS(req.Parameters)
-
 	switch opIDInProgress, inProgress, err := svc.bindStateGetter.IsBindingInProgress(iID, bID); true {
 	case err != nil:
 		return nil, &osb.HTTPStatusCodeError{StatusCode: http.StatusInternalServerError, ErrorMessage: strPtr(fmt.Sprintf("while checking if service binding is being created: %v", err))}
@@ -68,7 +65,7 @@ func (svc *bindService) Bind(ctx context.Context, osbCtx OsbContext, req *osb.Bi
 		return nil, &osb.HTTPStatusCodeError{StatusCode: http.StatusInternalServerError, ErrorMessage: strPtr(fmt.Sprintf("while checking if service binding for service instance already exists: %v", err))}
 	case state:
 		opID := bindOp.OperationID
-		bindInput, err := svc.prepareBindInput(osbCtx, iID, bID, svcID, svcPlanID, opID, paramHash)
+		bindInput, err := svc.prepareBindInput(osbCtx, iID, bID, svcID, svcPlanID, opID)
 		if err != nil {
 			return nil, err
 		}
@@ -91,7 +88,7 @@ func (svc *bindService) Bind(ctx context.Context, osbCtx OsbContext, req *osb.Bi
 		}, nil
 	}
 
-	op, err := svc.prepareBindOperation(iID, bID, paramHash)
+	op, err := svc.prepareBindOperation(iID, bID)
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +99,7 @@ func (svc *bindService) Bind(ctx context.Context, osbCtx OsbContext, req *osb.Bi
 
 	opID := op.OperationID
 
-	bindInput, err := svc.prepareBindInput(osbCtx, iID, bID, svcID, svcPlanID, opID, paramHash)
+	bindInput, err := svc.prepareBindInput(osbCtx, iID, bID, svcID, svcPlanID, opID)
 	if err != nil {
 		return nil, err
 	}
@@ -207,7 +204,7 @@ type bindingInput struct {
 	isAddonBindable bool
 }
 
-func (svc *bindService) prepareBindInput(osbCtx OsbContext, iID internal.InstanceID, bID internal.BindingID, svcID internal.ServiceID, svcPlanID internal.ServicePlanID, opID internal.OperationID, paramHash string) (bindingInput, *osb.HTTPStatusCodeError) {
+func (svc *bindService) prepareBindInput(osbCtx OsbContext, iID internal.InstanceID, bID internal.BindingID, svcID internal.ServiceID, svcPlanID internal.ServicePlanID, opID internal.OperationID) (bindingInput, *osb.HTTPStatusCodeError) {
 	instance, err := svc.instanceGetter.Get(iID)
 	switch {
 	case IsNotFoundError(err):
@@ -244,7 +241,7 @@ func (svc *bindService) prepareBindInput(osbCtx OsbContext, iID internal.Instanc
 	return bindInput, nil
 }
 
-func (svc *bindService) prepareBindOperation(iID internal.InstanceID, bID internal.BindingID, paramHash string) (internal.BindOperation, *osb.HTTPStatusCodeError) {
+func (svc *bindService) prepareBindOperation(iID internal.InstanceID, bID internal.BindingID) (internal.BindOperation, *osb.HTTPStatusCodeError) {
 	opID, err := svc.operationIDProvider()
 	if err != nil {
 		return internal.BindOperation{}, &osb.HTTPStatusCodeError{StatusCode: http.StatusInternalServerError, ErrorMessage: strPtr(fmt.Sprintf("while preparing bind operation: %v", err))}

--- a/internal/broker/bind_test.go
+++ b/internal/broker/bind_test.go
@@ -121,7 +121,6 @@ func TestBindServiceBindSuccessAsyncWhenNotBound(t *testing.T) {
 	bosMock := &automock.BindOperationStorage{}
 	defer bosMock.AssertExpectations(t)
 	expBindOp := ts.FixBindOperation(internal.OperationTypeCreate, internal.OperationStateInProgress)
-	expBindOp.ParamsHash = params
 	bosMock.On("Insert", &expBindOp).Return(nil).Once()
 	operationSucceeded := make(chan struct{})
 	bosMock.On("UpdateStateDesc", ts.Exp.InstanceID, ts.Exp.BindingID, ts.Exp.OperationID, internal.OperationStateSucceeded, mock.Anything).Return(nil).Once().
@@ -256,7 +255,6 @@ func TestBindServiceBindFailureAsyncWhenNotBoundOnChartGet(t *testing.T) {
 	bosMock := &automock.BindOperationStorage{}
 	defer bosMock.AssertExpectations(t)
 	expBindOp := ts.FixBindOperation(internal.OperationTypeCreate, internal.OperationStateInProgress)
-	expBindOp.ParamsHash = params
 	bosMock.On("Insert", &expBindOp).Return(nil).Once()
 	operationFailed := make(chan struct{})
 	bosMock.On("UpdateStateDesc", ts.Exp.InstanceID, ts.Exp.BindingID, ts.Exp.OperationID, internal.OperationStateFailed, mock.Anything).Return(nil).Once().
@@ -336,7 +334,6 @@ func TestBindServiceBindFailureWhenNotBoundAsyncOnRenderAndResolve(t *testing.T)
 	bosMock := &automock.BindOperationStorage{}
 	defer bosMock.AssertExpectations(t)
 	expBindOp := ts.FixBindOperation(internal.OperationTypeCreate, internal.OperationStateInProgress)
-	expBindOp.ParamsHash = params
 	bosMock.On("Insert", &expBindOp).Return(nil).Once()
 	operationFailed := make(chan struct{})
 	bosMock.On("UpdateStateDesc", ts.Exp.InstanceID, ts.Exp.BindingID, ts.Exp.OperationID, internal.OperationStateFailed, mock.Anything).Return(nil).Once().
@@ -424,8 +421,6 @@ func TestBindServiceBindSuccessAsyncWhenBound(t *testing.T) {
 	bosMock := &automock.BindOperationStorage{}
 	defer bosMock.AssertExpectations(t)
 	expBindOp := ts.FixBindOperation(internal.OperationTypeCreate, internal.OperationStateSucceeded)
-	params := jsonhash.HashS(ts.FixBindRequest().Parameters)
-	expBindOp.ParamsHash = params
 	operationSucceeded := make(chan struct{})
 	bosMock.On("UpdateStateDesc", ts.Exp.InstanceID, ts.Exp.BindingID, ts.Exp.OperationID, internal.OperationStateSucceeded, mock.Anything).Return(nil).Once().
 		Run(func(mock.Arguments) { close(operationSucceeded) })
@@ -515,9 +510,6 @@ func TestBindServiceBindFailureAsyncWhenBoundOnGetIbd(t *testing.T) {
 
 	bosMock := &automock.BindOperationStorage{}
 	defer bosMock.AssertExpectations(t)
-	expBindOp := ts.FixBindOperation(internal.OperationTypeCreate, internal.OperationStateInProgress)
-	params := jsonhash.HashS(ts.FixBindRequest().Parameters)
-	expBindOp.ParamsHash = params
 	operationSucceeded := make(chan struct{})
 	bosMock.On("UpdateStateDesc", ts.Exp.InstanceID, ts.Exp.BindingID, ts.Exp.OperationID, internal.OperationStateSucceeded, mock.Anything).Return(nil).Once().
 		Run(func(mock.Arguments) { close(operationSucceeded) })

--- a/internal/broker/bind_test.go
+++ b/internal/broker/bind_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	jsonhash "github.com/komkom/go-jsonhash"
 	"github.com/kyma-project/helm-broker/internal"
 	"github.com/kyma-project/helm-broker/internal/bind"
 	osb "github.com/pmorie/go-open-service-broker-client/v2"
@@ -109,8 +108,6 @@ func TestBindServiceBindSuccessAsyncWhenNotBound(t *testing.T) {
 	isMock := &automock.InstanceStorage{}
 	defer isMock.AssertExpectations(t)
 	expInstance := ts.FixInstanceWithInfo()
-	params := jsonhash.HashS(ts.FixBindRequest().Parameters)
-	expInstance.ParamsHash = params
 	isMock.On("Get", ts.Exp.InstanceID).Return(&expInstance, nil).Once()
 
 	ibdsMock := &automock.InstanceBindDataStorage{}
@@ -246,8 +243,6 @@ func TestBindServiceBindFailureAsyncWhenNotBoundOnChartGet(t *testing.T) {
 	isMock := &automock.InstanceStorage{}
 	defer isMock.AssertExpectations(t)
 	expInstance := ts.FixInstanceWithInfo()
-	params := jsonhash.HashS(ts.FixBindRequest().Parameters)
-	expInstance.ParamsHash = params
 	isMock.On("Get", ts.Exp.InstanceID).Return(&expInstance, nil).Once()
 
 	ibdsMock := &automock.InstanceBindDataStorage{}
@@ -324,8 +319,6 @@ func TestBindServiceBindFailureWhenNotBoundAsyncOnRenderAndResolve(t *testing.T)
 	isMock := &automock.InstanceStorage{}
 	defer isMock.AssertExpectations(t)
 	expInstance := ts.FixInstanceWithInfo()
-	params := jsonhash.HashS(ts.FixBindRequest().Parameters)
-	expInstance.ParamsHash = params
 	isMock.On("Get", ts.Exp.InstanceID).Return(&expInstance, nil).Once()
 
 	ibdsMock := &automock.InstanceBindDataStorage{}

--- a/internal/broker/deprovision.go
+++ b/internal/broker/deprovision.go
@@ -78,15 +78,14 @@ func (svc *deprovisionService) Deprovision(ctx context.Context, osbCtx OsbContex
 	//svcID := internal.ServiceID(req.ServiceID)
 	//svcPlanID := internal.ServicePlanID(req.PlanID)
 
-	// TODO: add support for calculating ParamHash
-	paramHash := "TODO"
-
 	op := internal.InstanceOperation{
 		InstanceID:  iID,
 		OperationID: opID,
 		Type:        internal.OperationTypeRemove,
 		State:       internal.OperationStateInProgress,
-		ParamsHash:  paramHash,
+		ProvisioningParameters: &internal.ProvisioningParameters{
+			Data: make(map[string]interface{}),
+		},
 	}
 
 	if err := svc.operationInserter.Insert(&op); err != nil {

--- a/internal/broker/deprovision.go
+++ b/internal/broker/deprovision.go
@@ -83,7 +83,7 @@ func (svc *deprovisionService) Deprovision(ctx context.Context, osbCtx OsbContex
 		OperationID: opID,
 		Type:        internal.OperationTypeRemove,
 		State:       internal.OperationStateInProgress,
-		ProvisioningParameters: &internal.ProvisioningParameters{
+		ProvisioningParameters: &internal.RequestParameters{
 			Data: make(map[string]interface{}),
 		},
 	}

--- a/internal/broker/deprovision_test.go
+++ b/internal/broker/deprovision_test.go
@@ -437,7 +437,7 @@ func (ts *deprovisionServiceTestSuite) FixInstance() internal.Instance {
 }
 
 func (ts *deprovisionServiceTestSuite) FixInstanceOperation() internal.InstanceOperation {
-	return *ts.Exp.NewInstanceOperation(internal.OperationTypeRemove, internal.OperationStateInProgress)
+	return *ts.Exp.NewInstanceOperationWithEmptyParams(internal.OperationTypeRemove, internal.OperationStateInProgress)
 }
 
 func (ts *deprovisionServiceTestSuite) FixDeprovisionRequest() osb.DeprovisionRequest {

--- a/internal/broker/fixture_test.go
+++ b/internal/broker/fixture_test.go
@@ -44,7 +44,7 @@ type expAll struct {
 		Revision int
 		Config   *chart.Config
 	}
-	ProvisioningParameters        *internal.ProvisioningParameters
+	ProvisioningParameters        *internal.RequestParameters
 	RequestProvisioningParameters map[string]interface{}
 }
 
@@ -80,7 +80,7 @@ func (exp *expAll) Populate() {
 	exp.ReleaseInfo.Config = &chart.Config{
 		Raw: "raw-config",
 	}
-	exp.ProvisioningParameters = &internal.ProvisioningParameters{
+	exp.ProvisioningParameters = &internal.RequestParameters{
 		Data: map[string]interface{}{
 			"addonsRepositoryURL": exp.Addon.RepositoryURL,
 		},
@@ -201,7 +201,7 @@ func (exp *expAll) NewInstanceOperationWithEmptyParams(tpe internal.OperationTyp
 		OperationID:            exp.OperationID,
 		Type:                   tpe,
 		State:                  state,
-		ProvisioningParameters: &internal.ProvisioningParameters{Data: make(map[string]interface{})},
+		ProvisioningParameters: &internal.RequestParameters{Data: make(map[string]interface{})},
 	}
 }
 

--- a/internal/broker/fixture_test.go
+++ b/internal/broker/fixture_test.go
@@ -39,12 +39,13 @@ type expAll struct {
 	}
 	Namespace   internal.Namespace
 	ReleaseName internal.ReleaseName
-	ParamsHash  string
 	ReleaseInfo struct {
 		Time     *google_protobuf.Timestamp
 		Revision int
 		Config   *chart.Config
 	}
+	ProvisioningParameters        *internal.ProvisioningParameters
+	RequestProvisioningParameters map[string]interface{}
 }
 
 func (exp *expAll) Populate() {
@@ -71,7 +72,6 @@ func (exp *expAll) Populate() {
 
 	exp.Namespace = internal.Namespace("fix-namespace")
 	exp.ReleaseName = internal.ReleaseName(fmt.Sprintf("hb-%s-%s-%s", exp.Addon.Name, exp.AddonPlan.Name, exp.InstanceID))
-	exp.ParamsHash = "TODO"
 	exp.ReleaseInfo.Time = &google_protobuf.Timestamp{
 		Seconds: 123123123,
 		Nanos:   1,
@@ -79,6 +79,14 @@ func (exp *expAll) Populate() {
 	exp.ReleaseInfo.Revision = 123
 	exp.ReleaseInfo.Config = &chart.Config{
 		Raw: "raw-config",
+	}
+	exp.ProvisioningParameters = &internal.ProvisioningParameters{
+		Data: map[string]interface{}{
+			"addonsRepositoryURL": exp.Addon.RepositoryURL,
+		},
+	}
+	exp.RequestProvisioningParameters = map[string]interface{}{
+		"addonsRepositoryURL": "different-fix-url",
 	}
 }
 
@@ -134,12 +142,12 @@ func (exp *expAll) NewAddon() *internal.Addon {
 
 func (exp *expAll) NewInstance() *internal.Instance {
 	return &internal.Instance{
-		ID:            exp.InstanceID,
-		ServiceID:     exp.Service.ID,
-		ServicePlanID: exp.ServicePlan.ID,
-		ReleaseName:   exp.ReleaseName,
-		Namespace:     exp.Namespace,
-		ParamsHash:    exp.ParamsHash,
+		ID:                     exp.InstanceID,
+		ServiceID:              exp.Service.ID,
+		ServicePlanID:          exp.ServicePlan.ID,
+		ReleaseName:            exp.ReleaseName,
+		Namespace:              exp.Namespace,
+		ProvisioningParameters: exp.ProvisioningParameters,
 	}
 }
 
@@ -154,13 +162,13 @@ func (exp *expAll) NewReleaseInfo() internal.ReleaseInfo {
 func (exp *expAll) NewInstanceWithInfo() *internal.Instance {
 	r := exp.NewReleaseInfo()
 	return &internal.Instance{
-		ID:            exp.InstanceID,
-		ServiceID:     exp.Service.ID,
-		ServicePlanID: exp.ServicePlan.ID,
-		ReleaseName:   exp.ReleaseName,
-		Namespace:     exp.Namespace,
-		ParamsHash:    exp.ParamsHash,
-		ReleaseInfo:   r,
+		ID:                     exp.InstanceID,
+		ServiceID:              exp.Service.ID,
+		ServicePlanID:          exp.ServicePlan.ID,
+		ReleaseName:            exp.ReleaseName,
+		Namespace:              exp.Namespace,
+		ProvisioningParameters: exp.ProvisioningParameters,
+		ReleaseInfo:            r,
 	}
 }
 
@@ -179,11 +187,21 @@ func (exp *expAll) NewInstanceCredentials() *internal.InstanceCredentials {
 
 func (exp *expAll) NewInstanceOperation(tpe internal.OperationType, state internal.OperationState) *internal.InstanceOperation {
 	return &internal.InstanceOperation{
-		InstanceID:  exp.InstanceID,
-		OperationID: exp.OperationID,
-		Type:        tpe,
-		State:       state,
-		ParamsHash:  exp.ParamsHash,
+		InstanceID:             exp.InstanceID,
+		OperationID:            exp.OperationID,
+		Type:                   tpe,
+		State:                  state,
+		ProvisioningParameters: exp.ProvisioningParameters,
+	}
+}
+
+func (exp *expAll) NewInstanceOperationWithEmptyParams(tpe internal.OperationType, state internal.OperationState) *internal.InstanceOperation {
+	return &internal.InstanceOperation{
+		InstanceID:             exp.InstanceID,
+		OperationID:            exp.OperationID,
+		Type:                   tpe,
+		State:                  state,
+		ProvisioningParameters: &internal.ProvisioningParameters{Data: make(map[string]interface{})},
 	}
 }
 

--- a/internal/broker/fixture_test.go
+++ b/internal/broker/fixture_test.go
@@ -194,7 +194,6 @@ func (exp *expAll) NewBindOperation(tpe internal.OperationType, state internal.O
 		OperationID: exp.OperationID,
 		Type:        tpe,
 		State:       state,
-		ParamsHash:  exp.ParamsHash,
 	}
 }
 
@@ -206,7 +205,6 @@ func (exp *expAll) NewBindOperationCollection() []*internal.BindOperation {
 			OperationID: exp.OperationID,
 			Type:        internal.OperationTypeCreate,
 			State:       internal.OperationStateSucceeded,
-			ParamsHash:  exp.ParamsHash,
 		},
 		&internal.BindOperation{
 			InstanceID:  "new-id-not-exist-1",
@@ -214,7 +212,6 @@ func (exp *expAll) NewBindOperationCollection() []*internal.BindOperation {
 			OperationID: "new-opid-not-exists-1",
 			Type:        internal.OperationTypeCreate,
 			State:       internal.OperationStateSucceeded,
-			ParamsHash:  exp.ParamsHash,
 		},
 		&internal.BindOperation{
 			InstanceID:  "new-id-not-exist-1",
@@ -222,7 +219,6 @@ func (exp *expAll) NewBindOperationCollection() []*internal.BindOperation {
 			OperationID: "new-opid-not-exists-1",
 			Type:        internal.OperationTypeCreate,
 			State:       internal.OperationStateSucceeded,
-			ParamsHash:  exp.ParamsHash,
 		},
 	}
 }

--- a/internal/broker/provision.go
+++ b/internal/broker/provision.go
@@ -48,7 +48,7 @@ func (svc *provisionService) Provision(ctx context.Context, osbCtx OsbContext, r
 	defer svc.mu.Unlock()
 
 	iID := internal.InstanceID(req.InstanceID)
-	requestedProvisioningParameters := internal.ProvisioningParameters{
+	requestedProvisioningParameters := internal.RequestParameters{
 		Data: req.Parameters,
 	}
 
@@ -67,7 +67,7 @@ func (svc *provisionService) Provision(ctx context.Context, osbCtx OsbContext, r
 
 	switch opIDInProgress, inProgress, err := svc.instanceStateGetter.IsProvisioningInProgress(iID); {
 	case err != nil:
-		return nil, &osb.HTTPStatusCodeError{StatusCode: http.StatusInternalServerError, ErrorMessage: strPtr(fmt.Sprintf("service instance exists with different parameters: %v", req.Parameters))}
+		return nil, &osb.HTTPStatusCodeError{StatusCode: http.StatusInternalServerError, ErrorMessage: strPtr(fmt.Sprintf("while checking if instance provisioning is in progress: %v", err))}
 	case inProgress:
 		opKeyInProgress := osb.OperationKey(opIDInProgress)
 		return &osb.ProvisionResponse{Async: true, OperationKey: &opKeyInProgress}, nil
@@ -259,7 +259,7 @@ func (svc *provisionService) do(ctx context.Context, input provisioningInput) {
 	}
 }
 
-func (svc *provisionService) requestedParametersAreDifferent(iID internal.InstanceID, requestedParams internal.ProvisioningParameters) (bool, error) {
+func (svc *provisionService) requestedParametersAreDifferent(iID internal.InstanceID, requestedParams internal.RequestParameters) (bool, error) {
 	instance, err := svc.instanceGetter.Get(iID)
 	if err != nil {
 		return false, errors.Wrapf(err, "while getting instance %s from storage", iID)

--- a/internal/model.go
+++ b/internal/model.go
@@ -342,10 +342,6 @@ type BindOperation struct {
 	State            OperationState
 	StateDescription *string
 
-	// ParamsHash is an immutable hash for operation parameters
-	// used to match requests.
-	ParamsHash string
-
 	// CreatedAt points to creation time of the operation.
 	// Field should be treated as immutable and is responsibility of storage implementation.
 	// It should be set by storage InsertBindOperation method.

--- a/internal/model.go
+++ b/internal/model.go
@@ -274,15 +274,12 @@ func (id OperationID) IsZero() bool { return id == OperationID("") }
 
 // InstanceOperation represents single provisioning operation.
 type InstanceOperation struct {
-	InstanceID       InstanceID
-	OperationID      OperationID
-	Type             OperationType
-	State            OperationState
-	StateDescription *string
-
-	// ParamsHash is an immutable hash for operation parameters
-	// used to match requests.
-	ParamsHash string
+	InstanceID             InstanceID
+	OperationID            OperationID
+	Type                   OperationType
+	State                  OperationState
+	StateDescription       *string
+	ProvisioningParameters *ProvisioningParameters
 
 	// CreatedAt points to creation time of the operation.
 	// Field should be treated as immutable and is responsibility of storage implementation.
@@ -308,6 +305,18 @@ func (id ServicePlanID) IsZero() bool { return id == ServicePlanID("") }
 // Namespace is the name of namespace in k8s
 type Namespace string
 
+// ReleaseInfo contains additional data about release installed on instance provisioning.
+type ReleaseInfo struct {
+	Time     *google_protobuf.Timestamp
+	Revision int
+	Config   *chart.Config
+}
+
+// ProvisioningParameters wraps a map containing provided YAML with provisioning parameters
+type ProvisioningParameters struct {
+	Data map[string]interface{}
+}
+
 const (
 	// ClusterWide is a value which refers to cluster wide resources.
 	ClusterWide Namespace = ""
@@ -315,13 +324,13 @@ const (
 
 // Instance contains info about Service exposed via Service Catalog.
 type Instance struct {
-	ID            InstanceID
-	ServiceID     ServiceID
-	ServicePlanID ServicePlanID
-	ReleaseName   ReleaseName
-	Namespace     Namespace
-	ParamsHash    string
-	ReleaseInfo   ReleaseInfo
+	ID                     InstanceID
+	ServiceID              ServiceID
+	ServicePlanID          ServicePlanID
+	ReleaseName            ReleaseName
+	Namespace              Namespace
+	ReleaseInfo            ReleaseInfo
+	ProvisioningParameters *ProvisioningParameters
 }
 
 // InstanceCredentials are created when we bind a service instance.
@@ -352,13 +361,6 @@ type BindOperation struct {
 type InstanceBindData struct {
 	InstanceID  InstanceID
 	Credentials InstanceCredentials
-}
-
-// ReleaseInfo contains additional data about release installed on instance provisioning.
-type ReleaseInfo struct {
-	Time     *google_protobuf.Timestamp
-	Revision int
-	Config   *chart.Config
 }
 
 // OperationState defines the possible states of an asynchronous request to a broker.

--- a/internal/model.go
+++ b/internal/model.go
@@ -279,7 +279,7 @@ type InstanceOperation struct {
 	Type                   OperationType
 	State                  OperationState
 	StateDescription       *string
-	ProvisioningParameters *ProvisioningParameters
+	ProvisioningParameters *RequestParameters
 
 	// CreatedAt points to creation time of the operation.
 	// Field should be treated as immutable and is responsibility of storage implementation.
@@ -312,8 +312,8 @@ type ReleaseInfo struct {
 	Config   *chart.Config
 }
 
-// ProvisioningParameters wraps a map containing provided YAML with provisioning parameters
-type ProvisioningParameters struct {
+// RequestParameters wraps a map containing provided YAML with parameters from request
+type RequestParameters struct {
 	Data map[string]interface{}
 }
 
@@ -330,7 +330,7 @@ type Instance struct {
 	ReleaseName            ReleaseName
 	Namespace              Namespace
 	ReleaseInfo            ReleaseInfo
-	ProvisioningParameters *ProvisioningParameters
+	ProvisioningParameters *RequestParameters
 }
 
 // InstanceCredentials are created when we bind a service instance.

--- a/internal/storage/driver/etcd/entity_operation.go
+++ b/internal/storage/driver/etcd/entity_operation.go
@@ -163,6 +163,7 @@ func (*InstanceOperation) handleGetError(errIn error) error {
 func (s *InstanceOperation) encodeDMToDSO(dm *internal.InstanceOperation) (string, error) {
 	buf := bytes.Buffer{}
 	enc := gob.NewEncoder(&buf)
+	gob.Register(map[string]interface{}{})
 	if err := enc.Encode(dm); err != nil {
 		return "", errors.Wrap(err, "while encoding entity")
 	}

--- a/internal/storage/testing/instance_test.go
+++ b/internal/storage/testing/instance_test.go
@@ -129,17 +129,20 @@ type instanceTestSuite struct {
 }
 
 func (ts *instanceTestSuite) generateFixtures() {
-	for fs, ft := range map[string]struct{ id, sID, spID, rName, pHash string }{
-		"A1": {"id-01", "sID-01", "spID-01", "rName-01-01", "pHash-01"},
-		"A2": {"id-02", "sID-01", "spID-01", "rName-01-02", "pHash-02"},
-		"A3": {"id-03", "sID-03", "spID-03", "rName-03", "pHash-03"},
+	for fs, ft := range map[string]struct {
+		id, sID, spID, rName string
+		params               map[string]interface{}
+	}{
+		"A1": {"id-01", "sID-01", "spID-01", "rName-01-01", map[string]interface{}{"param-01": "value-01"}},
+		"A2": {"id-02", "sID-01", "spID-01", "rName-01-02", map[string]interface{}{"param-02": "value-02"}},
+		"A3": {"id-03", "sID-03", "spID-03", "rName-03", map[string]interface{}{"param-03": "value-03"}},
 	} {
 		i := &internal.Instance{
-			ID:            internal.InstanceID(ft.id),
-			ServiceID:     internal.ServiceID(ft.sID),
-			ServicePlanID: internal.ServicePlanID(ft.spID),
-			ReleaseName:   internal.ReleaseName(ft.rName),
-			ParamsHash:    ft.pHash,
+			ID:                     internal.InstanceID(ft.id),
+			ServiceID:              internal.ServiceID(ft.sID),
+			ServicePlanID:          internal.ServicePlanID(ft.spID),
+			ReleaseName:            internal.ReleaseName(ft.rName),
+			ProvisioningParameters: &internal.ProvisioningParameters{Data: ft.params},
 		}
 
 		ts.fixtures[i.ID] = i
@@ -171,11 +174,11 @@ func (ts *instanceTestSuite) MustGetFixture(sym string) *internal.Instance {
 // BEWARE: not all fields are copied, only those currently used in this test suite scope
 func (ts *instanceTestSuite) MustCopyFixture(in *internal.Instance) *internal.Instance {
 	return &internal.Instance{
-		ID:            in.ID,
-		ServiceID:     in.ServiceID,
-		ServicePlanID: in.ServicePlanID,
-		ReleaseName:   in.ReleaseName,
-		ParamsHash:    in.ParamsHash,
+		ID:                     in.ID,
+		ServiceID:              in.ServiceID,
+		ServicePlanID:          in.ServicePlanID,
+		ReleaseName:            in.ReleaseName,
+		ProvisioningParameters: in.ProvisioningParameters,
 	}
 }
 

--- a/internal/storage/testing/instance_test.go
+++ b/internal/storage/testing/instance_test.go
@@ -142,7 +142,7 @@ func (ts *instanceTestSuite) generateFixtures() {
 			ServiceID:              internal.ServiceID(ft.sID),
 			ServicePlanID:          internal.ServicePlanID(ft.spID),
 			ReleaseName:            internal.ReleaseName(ft.rName),
-			ProvisioningParameters: &internal.ProvisioningParameters{Data: ft.params},
+			ProvisioningParameters: &internal.RequestParameters{Data: ft.params},
 		}
 
 		ts.fixtures[i.ID] = i

--- a/internal/storage/testing/operation_test.go
+++ b/internal/storage/testing/operation_test.go
@@ -366,7 +366,7 @@ func (ts *operationTestSuite) generateFixtures() {
 			Type:                   ft.opType,
 			State:                  ft.opState,
 			StateDescription:       &ft.sDesc,
-			ProvisioningParameters: &internal.ProvisioningParameters{Data: ft.params},
+			ProvisioningParameters: &internal.RequestParameters{Data: ft.params},
 		}
 
 		ts.fixtures[ir] = &io

--- a/internal/storage/testing/operation_test.go
+++ b/internal/storage/testing/operation_test.go
@@ -340,16 +340,17 @@ type operationTestSuite struct {
 
 func (ts *operationTestSuite) generateFixtures() {
 	for _, ft := range []struct {
-		sym          string
-		iID, opID    string
-		opType       internal.OperationType
-		opState      internal.OperationState
-		sDesc, pHash string
+		sym       string
+		iID, opID string
+		opType    internal.OperationType
+		opState   internal.OperationState
+		sDesc     string
+		params    map[string]interface{}
 	}{
 		// Order is important as storage will reject insert if there is in ptogress operation for given instance.
-		{"i01/o01/Create/h1/InProgress", "iID-001", "oID-001-001", internal.OperationTypeCreate, internal.OperationStateInProgress, "state desc 001", "pHash-001"},
-		{"i02/o02/Create/h2/Succeeded", "iID-002", "oID-002-002", internal.OperationTypeCreate, internal.OperationStateSucceeded, "state desc 002", "pHash-002"},
-		{"i02/o03/Remove/h3/InProgress", "iID-002", "oID-002-003", internal.OperationTypeRemove, internal.OperationStateInProgress, "state desc 003", "pHash-003"},
+		{"i01/o01/Create/h1/InProgress", "iID-001", "oID-001-001", internal.OperationTypeCreate, internal.OperationStateInProgress, "state desc 001", map[string]interface{}{"param-001": "value-001"}},
+		{"i02/o02/Create/h2/Succeeded", "iID-002", "oID-002-002", internal.OperationTypeCreate, internal.OperationStateSucceeded, "state desc 002", map[string]interface{}{"param-002": "value-002"}},
+		{"i02/o03/Remove/h3/InProgress", "iID-002", "oID-002-003", internal.OperationTypeRemove, internal.OperationStateInProgress, "state desc 003", map[string]interface{}{"param-003": "value-003"}},
 	} {
 		iID := internal.InstanceID(ft.iID)
 		opID := internal.OperationID(ft.opID)
@@ -360,12 +361,12 @@ func (ts *operationTestSuite) generateFixtures() {
 		}
 
 		io := internal.InstanceOperation{
-			InstanceID:       iID,
-			OperationID:      opID,
-			Type:             ft.opType,
-			State:            ft.opState,
-			StateDescription: &ft.sDesc,
-			ParamsHash:       ft.pHash,
+			InstanceID:             iID,
+			OperationID:            opID,
+			Type:                   ft.opType,
+			State:                  ft.opState,
+			StateDescription:       &ft.sDesc,
+			ProvisioningParameters: &internal.ProvisioningParameters{Data: ft.params},
 		}
 
 		ts.fixtures[ir] = &io
@@ -400,12 +401,12 @@ func (ts *operationTestSuite) MustGetFixture(sym string) *internal.InstanceOpera
 
 func (ts *operationTestSuite) MustCopyFixture(in *internal.InstanceOperation) *internal.InstanceOperation {
 	out := internal.InstanceOperation{
-		InstanceID:  in.InstanceID,
-		OperationID: in.OperationID,
-		Type:        in.Type,
-		State:       in.State,
-		ParamsHash:  in.ParamsHash,
-		CreatedAt:   in.CreatedAt,
+		InstanceID:             in.InstanceID,
+		OperationID:            in.OperationID,
+		Type:                   in.Type,
+		State:                  in.State,
+		CreatedAt:              in.CreatedAt,
+		ProvisioningParameters: in.ProvisioningParameters,
 	}
 
 	if in.StateDescription != nil {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/master/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/master/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**
The library was used to generate a hash from Provisioning Parameters provided in Provision Request. We used it to identify conflicts described in OSB API specification - trying to provision Service Instance with ID that already exists, but with different parameters should result in HTTP 409 Conflict status code in response. The idea is to add Provisioning Parameters to existing Instance and Instance Operation models, which is better than hashing it in case of possible future enhancements like adding UPDATE method to Helm Broker etc.

**Possible follow-up**
A proper validation logic should be implemented too, so the system knows how to interpret provided parameters. Additionally, if Parameters provided in request could contain some sensitive data, the implementation should be extended with some kind of encryption OR the Provisioning Parameters should just contain reference to corresponding k8s secret. At the moment it is not needed as the parameters are YAML chart values.

Changes proposed in this pull request:

- Removed outdated library
- Added Provisioning Parameters to Instance and Operation model
- Removed 409 Conflict Status when Provisioning is in progress

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
[#6142](https://github.com/kyma-project/kyma/issues/6142)

