### PR TITLE
Fix helm broker health check memory leak

### DIFF
--- a/charts/helm-broker/templates/rbac.yaml
+++ b/charts/helm-broker/templates/rbac.yaml
@@ -18,7 +18,7 @@ rules:
   resources: ["servicebrokers", "clusterservicebrokers"]
   verbs: ["create","delete","list","get","update", "watch"]
 - apiGroups: ["servicecatalog.k8s.io"]
-  resources: ["serviceinstance", "serviceclass", "clusterserviceclass"]
+  resources: ["serviceinstances", "serviceclasses", "clusterserviceclasses"]
   verbs: ["list","get","update", "watch"]
 - apiGroups: ["rafter.kyma-project.io"]
   resources: ["clusterassetgroups", "assetgroups"]

--- a/internal/addon/provider/generic_dir_getter.go
+++ b/internal/addon/provider/generic_dir_getter.go
@@ -110,7 +110,9 @@ func (g *ClientModeDirGetter) AddonDocURL(name internal.AddonName, version inter
 		return "", exerr.Wrap(err, "while checking if doc exists")
 	}
 
-	err = archiver.Archive([]string{pathToDocs}, pathToTgz)
+	tar := archiver.NewTarGz()
+	tar.OverwriteExisting = true
+	err = tar.Archive([]string{pathToDocs}, pathToTgz)
 	if err != nil {
 		return "", exerr.Wrapf(err, "while creating archive '%s'", pathToTgz)
 	}

--- a/internal/health/health.go
+++ b/internal/health/health.go
@@ -13,6 +13,7 @@ func handleHealth(etcdURL string) func(w http.ResponseWriter, req *http.Request)
 				w.WriteHeader(http.StatusInternalServerError)
 				return
 			}
+			defer resp.Body.Close()
 			if resp.StatusCode != 200 {
 				w.WriteHeader(http.StatusInternalServerError)
 				return


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/master/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/master/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**
Memory leak in helm-broker was caused by a small bug in health check http server. After applying the fix we can see the improvment in Grafana dashboard:
<img width="458" alt="Screenshot 2020-01-07 at 16 33 00" src="https://user-images.githubusercontent.com/26189888/71907265-fb8ffa00-316b-11ea-8c3f-32b023344674.png">


Changes proposed in this pull request:

- Added closing http response body which was causing memory leak
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#63 

