### PR TITLE
Hide implementation details from error message

### DIFF
--- a/internal/controller/repository/repository_test.go
+++ b/internal/controller/repository/repository_test.go
@@ -39,5 +39,5 @@ func TestRepository_FetchingError(t *testing.T) {
 	// Then
 	assert.Equal(t, v1alpha1.RepositoryStatusFailed, tr.Repository.Status)
 	assert.Equal(t, v1alpha1.RepositoryURLFetchingError, tr.Repository.Reason)
-	assert.Equal(t, "Fetching repository failed due to error: 'bug'", tr.Repository.Message)
+	assert.Equal(t, "Addon repository unreachable", tr.Repository.Message)
 }

--- a/pkg/apis/addons/v1alpha1/reason.go
+++ b/pkg/apis/addons/v1alpha1/reason.go
@@ -48,7 +48,7 @@ func (r RepositoryStatusReason) String() string {
 func (r RepositoryStatusReason) Message() string {
 	switch r {
 	case RepositoryURLFetchingError:
-		return "Fetching repository failed due to error: '%v'"
+		return "Addon repository unreachable"
 	default:
 		return ""
 	}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Do not expose technical implementation details in add-on repo fetching error

**Related issue(s)**
Fixes https://github.com/kyma-project/console/issues/1472

