### PR TITLE
Update Helm Broker documentation CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,4 +8,4 @@
 * @polskikiel @mszostok @piotrmiskiewicz @PK85 @jasiu001 @adamwalach @ksputo @crabtree @kjaksik
 
 # All .md files
-*.md @kazydek @klaudiagrz @bszwarc @mmitoraj @majakurcius @alexandra-simeonova
+*.md @kazydek @klaudiagrz @mmitoraj @majakurcius @alexandra-simeonova @superojla


### PR DESCRIPTION
**Description**

Since Barbara Sz. (@bszwarc) left us in September and is no longer an active contributor, she should be removed from CODEOWNERS.  
At the same time, Justyna Sz. (@superojla) joined us in September and has been contributing to Kyma documentation, so it's time to add her to CODEOWNERS. 

Changes proposed in this pull request:

- Remove @bszwarc from documentation CODEOWNERS
- Add @superojla to documentation CODEOWNERS