### PR TITLE
Change testing addons version to a valid latest tag

### DIFF
--- a/hack/examples/sample-addons.yaml
+++ b/hack/examples/sample-addons.yaml
@@ -4,4 +4,4 @@ metadata:
   name: addons-cfg-sample
 spec:
   repositories:
-    - url: "https://github.com/kyma-project/addons/releases/download/latest/index-testing.yaml"
+    - url: "https://github.com/kyma-project/addons/releases/download/0.14.0/index-testing.yaml"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/master/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/master/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**
Current `latest` tag is not valid for Addons configuration, which results in downloading old charts with deprecated `apiVersion`: https://github.com/kyma-project/addons/blob/latest/addons/testing-0.0.1/chart/testing/templates/deploy.yaml

The user is unable to follow example usage tutorials, because `helm-broker` is trying to install a deprecated Chart and provisioning fails with error:
```
provisioning failed on error: while installing helm release: while installing release from chart with name [hb-testin-minima-3c36bc84-abfa-47b2-b186-0022faf154a1] in namespace [test]: unable to build kubernetes objects from release manifest: unable to recognize \"\": no matches for kind \"Deployment\" in version \"extensions/v1beta1\"",
```

Changes proposed in this pull request:

- Changed `testing-addons` version to latest release.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->


