### PR TITLE
Fix URLs in installation guide and script

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -23,7 +23,7 @@ kind create cluster
 
 3. Install Service Catalog as a Helm chart:
 ```bash
-helm repo add svc-cat https://svc-catalog-charts.storage.googleapis.com
+helm repo add svc-cat https://kubernetes-sigs.github.io/service-catalog
 helm install catalog svc-cat/catalog --namespace catalog --set asyncBindingOperationsEnabled=true
 ```
 

--- a/hack/run-dev-kind.sh
+++ b/hack/run-dev-kind.sh
@@ -57,7 +57,7 @@ install::helm_broker() {
 install::service_catalog() {
   shout "- Provisioning Service Catalog chart in ${SC_RELEASE_NAMESPACE} namespace..."
 
-  ${HELM_BINARY} repo add svc-cat https://svc-catalog-charts.storage.googleapis.com
+  ${HELM_BINARY} repo add svc-cat https://kubernetes-sigs.github.io/service-catalog
   ${HELM_BINARY} install "${SC_RELEASE_NAME}" svc-cat/catalog --namespace "${SC_RELEASE_NAMESPACE}" --wait --create-namespace
 }
 


### PR DESCRIPTION
**Description**

Files:
- docs/installation.md
- hack/run-dev-kind.sh

contain outdated URL that causes installation failure.

Old URL: https://svc-catalog-charts.storage.googleapis.com is causing installation failure (403 Forbidden).
New URL: https://kubernetes-sigs.github.io/service-catalog fixes the issue.

Changes proposed in this pull request:
- change URL in docs/installation.md,
- change URL in hack/run-dev-kind.sh.