### PR TITLE
Install OpenSSL from edge

### DIFF
--- a/deploy/controller/Dockerfile
+++ b/deploy/controller/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.15.0
 
-RUN apk add --no-cache git openssh expat git sqlite --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
+RUN apk add --no-cache --update git openssh expat git sqlite openssl --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
 RUN apk add --no-cache mercurial --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community
 RUN apk add --no-cache ca-certificates curl
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

OpenSSL from edge has version [1.1.1m-r1](https://pkgs.alpinelinux.org/package/edge/main/x86/openssl#), this is to remediate CVE-2021-4160 present in current `1.1.1l-r7`.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
