### PR TITLE
Install OpenSSL dev from edge

### DIFF
--- a/deploy/controller/Dockerfile
+++ b/deploy/controller/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.15.0
 
-RUN apk add --no-cache --update git openssh expat git sqlite openssl --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
+RUN apk add --no-cache --update git openssh expat git sqlite openssl openssl-dev --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
 RUN apk add --no-cache mercurial --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community
 RUN apk add --no-cache ca-certificates curl
 

--- a/deploy/controller/Dockerfile
+++ b/deploy/controller/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.15.0
 
-RUN apk add --no-cache --update git openssh expat git sqlite openssl openssl-dev --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
-RUN apk add --no-cache mercurial --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community
+RUN apk add --no-cache --update git openssh expat git sqlite openssl openssl-dev --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main
+RUN apk add --no-cache mercurial --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community
 RUN apk add --no-cache ca-certificates curl
 
 COPY ./start.sh /root/start.sh


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Recently, I updated only OpenSSL client but not the library, which was still installed from the stable repo.
```
$ docker run img openssl version
OpenSSL 1.1.1m  14 Dec 2021 (Library: OpenSSL 1.1.1l  24 Aug 2021)
```
this ensures the library is also the latest available from edge and not vulnerable to https://github.com/advisories/GHSA-ph2x-8239-7xc7
```
$ docker run img openssl version
OpenSSL 1.1.1m  14 Dec 2021
```

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/helm-broker/pull/192